### PR TITLE
Fix bug where geckodriver couldn't find firefox by allowing user to specify firefox path

### DIFF
--- a/twitchtube/config.py
+++ b/twitchtube/config.py
@@ -27,6 +27,7 @@ LIMIT = 100  # 1-100
 # selenium
 ROOT_PROFILE_PATH = r"C:/Users/USERNAME/AppData/Roaming/Mozilla/Firefox/Profiles/r4Nd0m.selenium"  # Path to the Firefox profile where you are logged into YouTube
 EXECUTABLE_PATH = r"geckodriver"
+FIREFOX_PATH = r"C:/Program Files/Mozilla Firefox/firefox.exe" #specify this if your gecko driver can't find firefox ("Expected browser binary location...")
 SLEEP = 3  # How many seconds Firefox should sleep for when uploading
 HEADLESS = True  # If True Firefox will be hidden (True/False)
 

--- a/twitchtube/config.py
+++ b/twitchtube/config.py
@@ -27,7 +27,7 @@ LIMIT = 100  # 1-100
 # selenium
 ROOT_PROFILE_PATH = r"C:/Users/USERNAME/AppData/Roaming/Mozilla/Firefox/Profiles/r4Nd0m.selenium"  # Path to the Firefox profile where you are logged into YouTube
 EXECUTABLE_PATH = r"geckodriver"
-FIREFOX_PATH = r"C:/Program Files/Mozilla Firefox/firefox.exe" #specify this if your gecko driver can't find firefox ("Expected browser binary location...")
+FIREFOX_PATH = r"" #specify this if your gecko driver can't find firefox ("Expected browser binary location...")
 SLEEP = 3  # How many seconds Firefox should sleep for when uploading
 HEADLESS = True  # If True Firefox will be hidden (True/False)
 

--- a/twitchtube/video.py
+++ b/twitchtube/video.py
@@ -22,7 +22,7 @@ def make_video(
     data: list = DATA,
     blacklist: list = BLACKLIST,
     # other
-    path: str = get_path(),
+    path: str = "",
     check_version: bool = CHECK_VERSION,
     # twitch
     client_id: str = CLIENT_ID,
@@ -64,6 +64,7 @@ def make_video(
     thumbnail: str = THUMBNAIL,
     tags: list = TAGS,
 ) -> None:
+    path = get_path()
     if check_version:
         try:
 

--- a/twitchtube/video.py
+++ b/twitchtube/video.py
@@ -13,6 +13,8 @@ from .exceptions import *
 from .logging import Log as log
 from .utils import *
 
+from selenium.webdriver.firefox.options import Options
+
 
 # add language as param
 def make_video(
@@ -31,6 +33,7 @@ def make_video(
     # selenium
     profile_path: str = ROOT_PROFILE_PATH,
     executable_path: str = EXECUTABLE_PATH,
+    firefox_path: str = FIREFOX_PATH,
     sleep: int = SLEEP,
     headless: bool = HEADLESS,
     debug: bool = DEBUG,
@@ -187,7 +190,13 @@ def make_video(
                 log.info("No Firefox profile path given, skipping upload")
 
             else:
-                upload = Upload(profile_path, executable_path, sleep, headless, debug)
+                if firefox_path != "":
+                    options = Options()
+                    options.binary_location = r"C:\Program Files\Mozilla Firefox\firefox.exe"
+
+                    upload = Upload(profile_path, executable_path, sleep, headless, debug, options=options)
+                else:
+                    upload = Upload(profile_path, executable_path, sleep, headless, debug)
 
                 log.info("Trying to upload video to YouTube")
 


### PR DESCRIPTION
* Fixed a bug where geckodriver couldn't find firefox by allowing user to specify firefox path
You can specify firefox path now in config: `FIREFOX_PATH`
* Fixed a bug where running make_video multiple times would not update the path leading to path already exists error
This happened for example if you were import make video from python script and making multiple videos